### PR TITLE
fix node name

### DIFF
--- a/src/ros-qualisys.cpp
+++ b/src/ros-qualisys.cpp
@@ -6,7 +6,7 @@
 
 int main(int argc, char* argv[]) {
   // Classic definition of the node.
-  ros::init(argc, argv, "ros-qualisys", ros::init_options::NoSigintHandler);
+  ros::init(argc, argv, "ros_qualisys", ros::init_options::NoSigintHandler);
 
   // Here it says that the namespace of the Node can be overwritten by the
   // launcher


### PR DESCRIPTION
Ros does not allow one to run a ros-node with a name containing a "-".

So I changed the default node name.